### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If no destination is specified after the `-d` flag the device's **Document** fol
 ```json
 {
     "save_dir": "/Users/devin/Documents/Supernote",
-    "device_url": "http://192.168.1.105:8089/"
+    "device_url": "http://192.168.1.105:8089/",
     "num_backups": 7,
     "cleanup": true,
     "truncate_log": 500


### PR DESCRIPTION
Missing "," at the end of "device_url": "http://192.168.1.105:8089/" can confuse users if they multiline the configuration file.

Awesome application, should be more promoted.
Thank you.

Regards,
Dag